### PR TITLE
Don't show files under org/app folders if they have folderId

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -56,7 +56,14 @@ function getFolderContents(el) {
 
   Fliplet.Media.Folders.get(options).then(function (response) {
     response.folders.forEach(addFolder);
-    response.files.forEach(addFile);
+    response.files.filter(function (file) {
+      // Don't show organizations/app files on root folder if they belong to a folder
+      if (!options.folderId) {
+        return !file.mediaFolderId;
+      }
+      return true;
+
+    }).forEach(addFile);
   });
 }
 


### PR DESCRIPTION
Files were showing on org folder and on his own folder.