### PR TITLE
Selectall checkbox bug

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -600,6 +600,11 @@
   visibility: visible;
 }
 
+.file-table-header .selectable .file-select {
+  opacity: 0;
+  visibility: hidden;
+}
+
 .file-table-header .selectable.active .file-select {
   opacity: 1;
   visibility: visible;

--- a/css/interface.css
+++ b/css/interface.css
@@ -588,8 +588,6 @@
 }
 
 .file-select {
-  opacity: 0;
-  visibility: hidden;
   width: 40px;
   height: 100%;
   text-align: center;

--- a/widget.json
+++ b/widget.json
@@ -1,6 +1,6 @@
 {
   "name": "File Manager",
-  "package": "com.fliplet.file-manager.selectall-check",
+  "package": "com.fliplet.file-manager",
   "version": "1.0.0",
   "icon": "img/icon.png",
   "tags": ["type:component", "category:general"],

--- a/widget.json
+++ b/widget.json
@@ -1,6 +1,6 @@
 {
   "name": "File Manager",
-  "package": "com.fliplet.file-manager.softobiz",
+  "package": "com.fliplet.file-manager.selectall-check",
   "version": "1.0.0",
   "icon": "img/icon.png",
   "tags": ["type:component", "category:general"],

--- a/widget.json
+++ b/widget.json
@@ -1,6 +1,6 @@
 {
   "name": "File Manager",
-  "package": "com.fliplet.file-manager",
+  "package": "com.fliplet.file-manager.softobiz",
   "version": "1.0.0",
   "icon": "img/icon.png",
   "tags": ["type:component", "category:general"],


### PR DESCRIPTION
## Issue

checkboxes/select all should be constantly visible. Select all checkbox in header only visible when 1 files is selected 
## Description

Fix made in interface.css

## Screenshots/screencasts

[checkbox visibility](https://drive.google.com/file/d/1VlVvVQT-SNxjAhn2XsXaSBPSK6hwotz6/view)


## Notes

