### PR TITLE
#4059, drag drop error

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -540,7 +540,7 @@ function uploadFiles(files) {
   });
   $progress.removeClass('hidden');
 
-  if(currentFolderId == null && currentAppId == null){
+  if (currentFolderId == null && currentAppId == null) {
     currentOrganisationId = currentOrgId;
   } else {
     currentOrganisationId = null;
@@ -703,7 +703,7 @@ $('.file-manager-wrapper')
     });
     $progress.removeClass('hidden');
 
-    if(currentFolderId == null && currentAppId == null){
+    if (currentFolderId == null && currentAppId == null) {
       currentOrganisationId = currentOrgId;
     } else {
       currentOrganisationId = null;

--- a/js/interface.js
+++ b/js/interface.js
@@ -548,7 +548,7 @@ function uploadFiles(files) {
   Fliplet.Media.Files.upload({
     folderId: currentFolderId,
     appId: currentAppId,
-    organizationId : currentOrganisationId,
+    organizationId: currentOrganisationId,
     name: file.name,
     data: formData,
     progress: function(percentage) {
@@ -711,7 +711,7 @@ $('.file-manager-wrapper')
     Fliplet.Media.Files.upload({
       folderId: currentFolderId,
       appId: currentAppId,
-      organizationId : currentOrganisationId,
+      organizationId: currentOrganisationId,
       name: file.name,
       data: formData,
       progress: function(percentage) {

--- a/js/interface.js
+++ b/js/interface.js
@@ -17,7 +17,7 @@ var templates = {
 var currentSelection;
 
 var currentOrgId;
-var CurrentOrganisationId = null;
+var currentOrganisationId = null;
 var currentFolderId;
 var currentAppId;
 var currentFolders;
@@ -541,14 +541,14 @@ function uploadFiles(files) {
   $progress.removeClass('hidden');
 
   if(currentFolderId == null && currentAppId == null){
-    CurrentOrganisationId = currentOrgId;
+    currentOrganisationId = currentOrgId;
   } else {
-    CurrentOrganisationId = null;
+    currentOrganisationId = null;
   }
   Fliplet.Media.Files.upload({
     folderId: currentFolderId,
     appId: currentAppId,
-    organizationId : CurrentOrganisationId,
+    organizationId : currentOrganisationId,
     name: file.name,
     data: formData,
     progress: function(percentage) {
@@ -704,14 +704,14 @@ $('.file-manager-wrapper')
     $progress.removeClass('hidden');
 
     if(currentFolderId == null && currentAppId == null){
-      CurrentOrganisationId = currentOrgId;
+      currentOrganisationId = currentOrgId;
     } else {
-      CurrentOrganisationId = null;
+      currentOrganisationId = null;
     }
     Fliplet.Media.Files.upload({
       folderId: currentFolderId,
       appId: currentAppId,
-      organizationId : CurrentOrganisationId,
+      organizationId : currentOrganisationId,
       name: file.name,
       data: formData,
       progress: function(percentage) {

--- a/js/interface.js
+++ b/js/interface.js
@@ -16,6 +16,8 @@ var templates = {
 // This should contain either app/org/folder of current folder
 var currentSelection;
 
+var currentOrgId;
+var CurrentOrganisationId = null;
 var currentFolderId;
 var currentAppId;
 var currentFolders;
@@ -272,6 +274,7 @@ function getFolderContents(el, isRootFolder) {
     switch (navItem.type) {
       case 'organizationId':
         // User is no longer browsing the organization folder
+        currentOrgId = options.organizationId
         if (options.hasOwnProperty('folderId') || !options.hasOwnProperty('organizationId') || parseInt(options.organizationId, 10) !== navItem.id) {
           return;
         }
@@ -523,6 +526,7 @@ function hideDropZone() {
 }
 
 function uploadFiles(files) {
+  
   var formData = new FormData();
   var file;
   for (var i = 0; i < files.length; i++) {
@@ -536,9 +540,15 @@ function uploadFiles(files) {
   });
   $progress.removeClass('hidden');
 
+  if(currentFolderId == null && currentAppId == null){
+    CurrentOrganisationId = currentOrgId;
+  } else {
+    CurrentOrganisationId = null;
+  }
   Fliplet.Media.Files.upload({
     folderId: currentFolderId,
     appId: currentAppId,
+    organizationId : CurrentOrganisationId,
     name: file.name,
     data: formData,
     progress: function(percentage) {
@@ -693,9 +703,15 @@ $('.file-manager-wrapper')
     });
     $progress.removeClass('hidden');
 
+    if(currentFolderId == null && currentAppId == null){
+      CurrentOrganisationId = currentOrgId;
+    } else {
+      CurrentOrganisationId = null;
+    }
     Fliplet.Media.Files.upload({
       folderId: currentFolderId,
       appId: currentAppId,
+      organizationId : CurrentOrganisationId,
       name: file.name,
       data: formData,
       progress: function(percentage) {

--- a/widget.json
+++ b/widget.json
@@ -1,6 +1,6 @@
 {
   "name": "File Manager",
-  "package": "com.fliplet.file-manager.org-drag-drop",
+  "package": "com.fliplet.file-manager.org-drag-drop", 
   "version": "1.0.0",
   "icon": "img/icon.png",
   "tags": ["type:component", "category:general"],

--- a/widget.json
+++ b/widget.json
@@ -1,6 +1,6 @@
 {
   "name": "File Manager",
-  "package": "com.fliplet.file-manager.org-drag-drop", 
+  "package": "com.fliplet.file-manager", 
   "version": "1.0.0",
   "icon": "img/icon.png",
   "tags": ["type:component", "category:general"],

--- a/widget.json
+++ b/widget.json
@@ -1,6 +1,6 @@
 {
   "name": "File Manager",
-  "package": "com.fliplet.file-manager",
+  "package": "com.fliplet.file-manager.softobiz",
   "version": "1.0.0",
   "icon": "img/icon.png",
   "tags": ["type:component", "category:general"],

--- a/widget.json
+++ b/widget.json
@@ -1,6 +1,6 @@
 {
   "name": "File Manager",
-  "package": "com.fliplet.file-manager.softobiz",
+  "package": "com.fliplet.file-manager.org-drag-drop",
   "version": "1.0.0",
   "icon": "img/icon.png",
   "tags": ["type:component", "category:general"],


### PR DESCRIPTION
## Issue

File manager overlay within Edit mode supports upload of files by dragging them onto the window but it doesn’t work reliably. Progress bar appears but it never completes. #4059

## Description

Fixed uploading of images by dragging them in upload area where loader was keeps on showing.

## Screenshots/screencasts

## Notes
