### PR TITLE
Checkboxes near folders/files in File manager disappear after removing of any item

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -1257,7 +1257,6 @@ $('.file-manager-wrapper')
 
             // Toggle checkbox header to false
             $('.file-table-header input[type="checkbox"]').prop('checked', false);
-            $selectAllCheckbox.css({'opacity': '0', 'visibility': 'hidden'});
           });
         } else {
           deletePromise = Fliplet.Media.Files.delete(itemID).then(function() {
@@ -1270,7 +1269,6 @@ $('.file-manager-wrapper')
 
             // Toggle checkbox header to false
             $('.file-table-header input[type="checkbox"]').prop('checked', false);
-            $selectAllCheckbox.css({'opacity': '0', 'visibility': 'hidden'});
           });
         }
 


### PR DESCRIPTION
@squallstar 

Fixed bug that caused the 'select-all' checkbox to disappear after deleting a file or folder.
Removed removed style that makes the 'select-all' checkbox to disappear.
Checkboxes near file/folder work fine.

ref Fliplet/fliplet-studio#4597.


![Upplabs task#64](https://user-images.githubusercontent.com/52824207/61438179-86273780-a947-11e9-8ad9-780941dbdd7a.gif)
![Upplabs task#65_2](https://user-images.githubusercontent.com/52824207/61440454-40b93900-a94c-11e9-9bf7-72b5ee4d4a83.gif)
