### PR TITLE
Search fixes

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -881,6 +881,7 @@ html {
   display: flex;
   width: 30%;
   z-index: 1;
+  position: relative;
 }
 
 .search-holder .search-term {
@@ -890,6 +891,20 @@ html {
 
 .search-holder .search-type {
   width: 190px;
+}
+
+.search-holder .search-term-clean {
+  position: absolute;
+  right: 20px;
+  top: 12px;
+  width: 40px;
+  height: 20px;
+  background-color: #00abd2;
+  color: white;
+  line-height: 20px;
+  border-radius: 2px;
+  padding: 0 2px;
+  cursor: pointer;
 }
 
 .search-result-cell {

--- a/css/interface.css
+++ b/css/interface.css
@@ -893,7 +893,7 @@ html {
   width: 190px;
 }
 
-.search-holder .search-term-clean {
+.search-holder .search-term-clear {
   position: absolute;
   right: 20px;
   top: 12px;
@@ -903,7 +903,7 @@ html {
   color: white;
   line-height: 20px;
   border-radius: 2px;
-  padding: 0 2px;
+  padding: 0 4px;
   cursor: pointer;
 }
 

--- a/interface.html
+++ b/interface.html
@@ -25,10 +25,11 @@
         </div>
         <div class="search-holder">
           <select class="form-control search-type">
-            <option value="all">All</option>
+            <option value="all">This organization</option>
             <option value="this-folder" selected>This folder</option>
           </select>
           <input type="text" class="form-control search-term" placeholder="Search...">
+          <div class="search-term-clean hide" id="search-term-clean">clean</div>
         </div>
         <div class="new-btn-holder">
           <button type="button" class="btn btn-primary new-btn">New</button>

--- a/interface.html
+++ b/interface.html
@@ -29,7 +29,7 @@
             <option value="this-folder" selected>This folder</option>
           </select>
           <input type="text" class="form-control search-term" placeholder="Search...">
-          <div class="search-term-clean hide" id="search-term-clean">clean</div>
+          <div class="search-term-clear hide" id="search-term-clear">clear</div>
         </div>
         <div class="new-btn-holder">
           <button type="button" class="btn btn-primary new-btn">New</button>

--- a/js/interface.js
+++ b/js/interface.js
@@ -14,6 +14,7 @@ var templates = {
 };
 var $searchType = $('.search-type');
 var $searchTerm = $('.search-term');
+var $searchTermCleanBtn = $('#search-term-clean');
 var $fileTable = $('.file-table');
 var $pagination = $('.pagination');
 var goToFolderAlertTimeout = 5000;
@@ -755,6 +756,7 @@ function renderSearchResult(result, searchType) {
 
   if (!result || !result.length) {
     showNothingFoundAlert(true);
+    removePagination();
     return;
   }
 
@@ -899,6 +901,7 @@ function enableSearchState() {
   $folderContents.empty();
   $fileTable.addClass('search-result');
   $newBtn.prop('disabled', true);
+  $searchTermCleanBtn.removeClass('hide');
   showNothingFoundAlert(false);
   beforeSearchNavStack = navStack;
 }
@@ -909,10 +912,24 @@ function disableSearchState() {
   $searchTerm.val('');
   $searchType.val('this-folder');
   $newBtn.prop('disabled', false);
+  $searchTermCleanBtn.addClass('hide');
   showNothingFoundAlert(false);
+  removePagination();
+}
+
+function removePagination() {
   if (!$pagination.is(':empty')) {
     $pagination.pagination('destroy');
   }
+}
+
+function updateSearchTypeOptions(type) {
+  var optionName = 'This organization';
+  if (type === 'app') {
+    optionName = 'This app';
+  }
+
+  $searchType.find('option:first').text(optionName);
 }
 
 // Shows content of the last folder before run search
@@ -1131,6 +1148,7 @@ $('.file-manager-wrapper')
     disableSearchState();
     resetUpTo($(this));
     getFolderContents($(this), true);
+    updateSearchTypeOptions($(this).data('type'));
   })
   .on('click', '[data-create-folder]', function(event) {
     // Creates folder
@@ -1400,6 +1418,10 @@ $('.file-manager-wrapper')
       });
 
   }, searchDebounceTime))
+  .on('click', '#search-term-clean', function () {
+    $searchTerm.val('').keyup();
+    $searchTermCleanBtn.addClass('hide');
+  })
   .on('click', '.path-link', function () {
     var $el = $(this);
     var type = $el.data('type');

--- a/js/interface.js
+++ b/js/interface.js
@@ -14,7 +14,7 @@ var templates = {
 };
 var $searchType = $('.search-type');
 var $searchTerm = $('.search-term');
-var $searchTermCleanBtn = $('#search-term-clean');
+var $searchTermClearBtn = $('#search-term-clear');
 var $fileTable = $('.file-table');
 var $pagination = $('.pagination');
 var goToFolderAlertTimeout = 5000;
@@ -901,7 +901,7 @@ function enableSearchState() {
   $folderContents.empty();
   $fileTable.addClass('search-result');
   $newBtn.prop('disabled', true);
-  $searchTermCleanBtn.removeClass('hide');
+  $searchTermClearBtn.removeClass('hide');
   showNothingFoundAlert(false);
   beforeSearchNavStack = navStack;
 }
@@ -912,7 +912,7 @@ function disableSearchState() {
   $searchTerm.val('');
   $searchType.val('this-folder');
   $newBtn.prop('disabled', false);
-  $searchTermCleanBtn.addClass('hide');
+  $searchTermClearBtn.addClass('hide');
   showNothingFoundAlert(false);
   removePagination();
 }
@@ -1418,9 +1418,9 @@ $('.file-manager-wrapper')
       });
 
   }, searchDebounceTime))
-  .on('click', '#search-term-clean', function () {
+  .on('click', '#search-term-clear', function () {
     $searchTerm.val('').keyup();
-    $searchTermCleanBtn.addClass('hide');
+    $searchTermClearBtn.addClass('hide');
   })
   .on('click', '.path-link', function () {
     var $el = $(this);


### PR DESCRIPTION
@squallstar 

**Fixed cases:**

1) Using the search, it's showing me a number of results at the bottom with the numbers of pages with results. When I update the search, this doesn't seem to update. See screen recording: https://drive.google.com/file/d/1yEpOu-LCGJk6OUVeapZdkiDGCPC8EIHD/view

ref https://github.com/Fliplet/fliplet-studio/issues/4607

![1](https://user-images.githubusercontent.com/1763029/61533866-b568a200-aa36-11e9-953c-e2febe1dea9d.gif)

2) Also, the search box should have a clear search option.

ref https://github.com/Fliplet/fliplet-studio/issues/4607

![2](https://user-images.githubusercontent.com/1763029/61533894-c74a4500-aa36-11e9-8a1c-f796acd0f8c1.gif)

3) We need to implement This app or This organization as an option for a search dropdown instead of All option. There shouldn’t be both at the same time, though. It should depend on whether the user is currently browsing with the organization or app folder selected on the left-hand

ref https://github.com/Fliplet/fliplet-studio/issues/4643

![3](https://user-images.githubusercontent.com/1763029/61533930-df21c900-aa36-11e9-89f1-249159910855.gif)
 side.

4) The file name seems to be trimmed way ahead of when it's actually necessary, see in this GIF
https://cl.ly/ff2d9f251d2d/Screen%252520Recording%2525202019-07-16%252520at%25252003.07%252520PM.gif

No ref to the Github issue

![4](https://user-images.githubusercontent.com/1763029/61533961-f2cd2f80-aa36-11e9-9c87-4c52d5df4d6d.gif)

