### PR TITLE
Input overlapping new button fix

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -887,6 +887,7 @@ html {
 .search-holder .search-term {
   margin-left: 10px;
   margin-right: 10px;
+  min-width: 0px;
 }
 
 .search-holder .search-type {
@@ -957,5 +958,11 @@ html {
 @media (max-width: 1280px) {
   .file-cell.file-path-cell {
     width: 100px;
+  }
+}
+
+@supports (-ms-ime-align: auto) {
+  .search-holder .search-type {
+    width: 120px;
   }
 }

--- a/css/interface.css
+++ b/css/interface.css
@@ -887,7 +887,7 @@ html {
 .search-holder .search-term {
   margin-left: 10px;
   margin-right: 10px;
-  min-width: 0px;
+  min-width: 65px;
 }
 
 .search-holder .search-type {
@@ -958,11 +958,5 @@ html {
 @media (max-width: 1280px) {
   .file-cell.file-path-cell {
     width: 100px;
-  }
-}
-
-@supports (-ms-ime-align: auto) {
-  .search-holder .search-type {
-    width: 120px;
   }
 }

--- a/js/interface.js
+++ b/js/interface.js
@@ -68,8 +68,12 @@ function getOrganizationsList() {
   }).then(function() {
     getAppsList();
     $selectAllCheckbox.addClass('active');
-  }).finally(function () {
     showSpinner(false);
+  }).catch(function (err) {
+    showSpinner(false);
+    Fliplet.Modal.alert({
+      message: Fliplet.parseError(err)
+    })
   });
 }
 
@@ -149,8 +153,12 @@ function getAppsList() {
     apps.forEach(addApps);
 
     navigateToDefaultFolder();
-  }).finally(function () {
     showSpinner(false);
+  }).catch(function (err) {
+    showSpinner(false);
+    Fliplet.Modal.alert({
+      message: Fliplet.parseError(err)
+    })
   });
 }
 
@@ -243,8 +251,13 @@ function getFolderContentsById(id, type, isSearchNav) {
     }
   }, function() {
     $('.empty-state').addClass('active');
-  }).finally(function () {
+  }).then(function () {
     showSpinner(false);
+  }).catch(function (err) {
+    showSpinner(false);
+    Fliplet.Modal.alert({
+      message: Fliplet.parseError(err)
+    })
   });
 }
 
@@ -359,8 +372,13 @@ function getFolderContents(el, isRootFolder) {
     }
   }, function() {
     $('.empty-state').addClass('active');
-  }).finally(function () {
+  }).then(function () {
     showSpinner(false);
+  }).catch(function (err) {
+    showSpinner(false);
+    Fliplet.Modal.alert({
+      message: Fliplet.parseError(err)
+    })
   });
 }
 
@@ -1183,8 +1201,12 @@ $('.file-manager-wrapper')
     Fliplet.Media.Folders.create(options).then(function (folder) {
       addFolder(folder);
       insertItem(folder, true);
-    }).finally(function () {
       showSpinner(false);
+    }).catch(function (err) {
+      showSpinner(false);
+      Fliplet.Modal.alert({
+        message: Fliplet.parseError(err)
+      })
     });
 
     $newBtn.click();
@@ -1290,9 +1312,14 @@ $('.file-manager-wrapper')
           });
         }
 
-        deletePromise.finally(function () {
+        deletePromise.then(function () {
           showSpinner(false);
-        })
+        }).catch(function (err) {
+          showSpinner(false);
+          Fliplet.Modal.alert({
+            message: Fliplet.parseError(err)
+          })
+        });
       });
     }
   })
@@ -1374,9 +1401,14 @@ $('.file-manager-wrapper')
         });
       }
 
-      updatePromise.finally(function () {
+      updatePromise.then(function () {
         showSpinner(false);
-      })
+      }).catch(function (err) {
+        showSpinner(false);
+        Fliplet.Modal.alert({
+          message: Fliplet.parseError(err)
+        })
+      });
     }
   })
   .on('click', '.header-breadcrumbs [data-breadcrumb]', function() {
@@ -1410,11 +1442,12 @@ $('.file-manager-wrapper')
     showSpinner(true);
 
     search(type, term)
-      .catch(function () {
-        alert('Error on search files');
-      })
-      .finally(function () {
+      .then(function () {
         showSpinner(false);
+      })
+      .catch(function () {
+        showSpinner(false);
+        alert('Error on search files');
       });
 
   }, searchDebounceTime))


### PR DESCRIPTION
@tonytlwu @squallstar 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/4655

## Description
Changed the min-width value of the input. Witch is worked for Edge 12-17 browser only, Edge 18 worked fine with the previous solution.
Also changed select width for a better input view.
## Screenshots/screencasts
![issue input overlapps](https://user-images.githubusercontent.com/53430352/63166605-9b22e380-c037-11e9-8220-32b8971d616d.png)

## Backward compatibility

This change is fully backward compatible.

## Notes
For the Edge 12-17, we need to add a polyfill to use .finally in Promise. As it was done for IE11.
Because of that the spinner-overlay isn't cloaking himself