### PR TITLE
Search in folder 4912

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -1139,9 +1139,10 @@ $('.file-manager-wrapper')
 
     removeSelection();
     hideSideActions();
-    disableSearchState();
 
     if ($parent.data('file-type') === 'folder') {
+      disableSearchState();
+
       // Store to nav stack
       backItem = _.find(folders, ['id', id]);
       backItem.tempElement = $('.file-row[data-id="' + id + '"]');


### PR DESCRIPTION
@squallstar @tonytlwu 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/4912
## Description
Transferred disableSearchState method into if statement for folder type to prevent search value  and the clear button disappears.
## Screenshots/screencasts
https://cl.ly/ebe99d9858c5
## Backward compatibility
This change is fully backward compatible.