### PR TITLE
Removed IE and Edge native clear button

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -890,6 +890,10 @@ html {
   min-width: 65px;
 }
 
+.search-term::-ms-clear {
+  display: none;
+}
+
 .search-holder .search-type {
   width: 190px;
 }


### PR DESCRIPTION
@tonytlwu @squallstar 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/4644

## Description
Removed IE and Edge native clear button

## Screenshots/screencasts
IE 11
![image](https://user-images.githubusercontent.com/53430352/65255183-21828780-db06-11e9-9b39-836100cf2344.png)

EDGE
![image](https://user-images.githubusercontent.com/53430352/65255278-44ad3700-db06-11e9-8e25-d8d633d89202.png)


## Backward compatibility

This change is fully backward compatible.
