### PR TITLE
CSS rule should be applied for all device sizes.

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -890,10 +890,6 @@ html {
   min-width: 65px;
 }
 
-.search-term::-ms-clear {
-  display: none;
-}
-
 .search-holder .search-type {
   width: 190px;
 }
@@ -961,4 +957,8 @@ html {
   .file-cell.file-path-cell {
     width: 100px;
   }
+}
+
+.search-term::-ms-clear {
+  display: none;
 }


### PR DESCRIPTION
@tonytlwu @squallstar 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/4644

## Description
CSS rule should be applied for all device sizes.

## Screenshots/screencasts
![image](https://user-images.githubusercontent.com/53430352/65522056-dba53500-def2-11e9-9097-5547d789ba1d.png)


## Backward compatibility

This change is fully backward compatible.