### PR TITLE
Updated rename modal

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -1405,9 +1405,15 @@ $('.file-manager-wrapper')
     var itemType = $('.file-row.active').data('file-type');
     var fileName = $('.file-row[data-id="' + itemID + '"]').find('.file-name span').text();
 
-    var changedName = prompt("Please enter the file name", fileName);
+    Fliplet.Modal.prompt({
+      title: 'Please enter the file name',
+      value: fileName
+    }).then(function(result) {
+      if (result === null) {
+        return;
+      }
 
-    if (changedName !== null) {
+      var changedName = result.trim();
       var updatePromise;
 
       showSpinner(true);
@@ -1438,9 +1444,9 @@ $('.file-manager-wrapper')
         showSpinner(false);
         Fliplet.Modal.alert({
           message: Fliplet.parseError(err)
-        })
+        });
       });
-    }
+    });
   })
   .on('click', '.header-breadcrumbs [data-breadcrumb]', function() {
     var index = $(this).data('breadcrumb');


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5642

## Description
Updated modal

## Screenshots/screencasts
![file-manager-rename](https://user-images.githubusercontent.com/52824207/73768463-b4ecea00-4781-11ea-989e-c6ea17c6266e.gif)

## Backward compatibility
This change is fully backward compatible.