### PR TITLE
Now selected file description is cleared when user switches folder

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -1187,6 +1187,9 @@ $('.file-manager-wrapper')
     }
   })
   .on('click', '.dropdown-menu-holder [data-browse-folder]', function(event) {
+    // Deselection of  all active files when user switches folder
+    $(this).parents('.file-manager-body').find('.file-row.active input[type="checkbox"]').click();
+
     disableSearchState();
     resetUpTo($(this));
     getFolderContents($(this), true);


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/4908

## Description
When the user switches to another folder all active files are deselected.
I used the same logic that is written to deselect files.

## Screenshots/screencasts
![files-deselect-fix](https://user-images.githubusercontent.com/52824207/74224722-0c2f1500-4cc2-11ea-99cf-80ff11042560.gif)

## Backward compatibility
This change is fully backward compatible.