### PR TITLE
When we are clearing search field search type stay as it was

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -949,7 +949,6 @@ function disableSearchState() {
   isActiveSearch = false;
   $fileTable.removeClass('search-result');
   $searchTerm.val('');
-  $searchType.val('this-folder');
   $newBtn.prop('disabled', false);
   $searchTermClearBtn.addClass('hide');
   showNothingFoundAlert(false);


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6023

## Description
When we are clearing search field search type stay as it was

## Screenshots/screencasts
https://share.getcloudapp.com/7KuR5OWk

## Backward compatibility

This change is fully backward compatible.