### PR TITLE
OD-212 [Fix] Hiding loading spinner when trash folder is empty

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -962,8 +962,9 @@ function getTrashFilesData(filterFiles, filterFolders) {
       $('.file-deleted-cell').show();
 
       renderList();
-      showSpinner(false);
     }
+
+    showSpinner(false);
   })
 }
 


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
OD-212 https://weboo.atlassian.net/browse/OD-212
## Description

Moved the action to hide loading spinner

## Screenshots/screencasts
http://somup.com/crfjohbL5a
## Backward compatibility
This change is fully backward compatible.
## Reviewers
@upplabs-alex-levchenko @ivandevupp @YaroslavOvdii 