### PR TITLE
ID-1119 [Fix] Authenticate thumbnails for media files when uploaded

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -1074,6 +1074,7 @@ function uploadFiles(files) {
     }
   }).then(function(files) {
     files.forEach(function(file) {
+      parseThumbnail(file);
       addFile(file);
       insertItem(file);
     });
@@ -1734,6 +1735,7 @@ $('.file-manager-wrapper')
     }).then(function(files) {
       $input.val('');
       files.forEach(function(file) {
+        parseThumbnail(file);
         addFile(file);
         insertItem(file);
       });


### PR DESCRIPTION
As part of the CORS changes I am making I have found that thumbnails for newly uploaded files were not correctly authenticated, so after the changes I am making they wouldn't show up.