### PR TITLE
OD-527 [FIX] files / folders are displayed when scrolling to the right

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -58,6 +58,7 @@ html {
   display: -ms-flexbox;
   display: flex;
   width: 260px;
+  position: relative;
   background-color: #ffffff;
   border-left: 1px solid #e4e9eb;
   padding: 15px;
@@ -239,7 +240,10 @@ html {
 }
 
 .side-actions {
+  position: sticky;
+  top: 10px;
   width: 100%;
+  height: max-content;
   text-align: center;
   display: none;
 }

--- a/css/interface.css
+++ b/css/interface.css
@@ -241,7 +241,7 @@ html {
 
 .side-actions {
   position: sticky;
-  top: 10px;
+  top: 10px;  /* gap to the header to avoid touch of elements */
   width: 100%;
   height: max-content;
   text-align: center;


### PR DESCRIPTION
@sofiiakvasnevska

OD-527 https://weboo.atlassian.net/browse/OD-527

## Description
Selected folders / files are now shown in the right pane when scrolling

## Screenshots/screencasts
https://storyxpress.co/video/kqqjz1ks2pzexn3og

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko