### PR TITLE
XOR-213 [FIX] Ensure progress bar updated when restore file/folder ha…

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -1916,7 +1916,7 @@ $('.file-manager-wrapper')
       ? { appId: $(this).data('app-id') }
       : { orgId: $(this).data('org-id') };
 
-    if(rootId.appId) {
+    if (rootId.appId) {
       updateAppMetrics(rootId.appId).then(function() {
         toggleStorageUsage();
       });

--- a/js/interface.js
+++ b/js/interface.js
@@ -1916,7 +1916,11 @@ $('.file-manager-wrapper')
       ? { appId: $(this).data('app-id') }
       : { orgId: $(this).data('org-id') };
 
-    toggleStorageUsage($(this));
+    if(rootId.appId) {
+      updateAppMetrics(rootId.appId).then(function() {
+        toggleStorageUsage();
+      });
+    }
 
     navigateToRootFolder(rootId);
   })


### PR DESCRIPTION
### Product areas affected

File-manager - Toggle Storage Usage on app selection which will update the progress bar when the user clicks on the app after restoring the file/folder from the Trash

### What does this PR do?

Toggle Storage Usage on app selection which will update the progress bar when the user clicks on the app after restoring the file/folder from the Trash

### JIRA ticket

[XOR-213](https://weboo.atlassian.net/browse/XOR-213)

### Result

https://user-images.githubusercontent.com/101858104/173319482-5c063d3a-d760-4829-9ea3-0a02ad6b4dba.mp4


### Checklist

None
### Deployment instructions

None
### Author concerns

None