### PR TITLE
fix(ID-3973): fixed possibility to navigate to search result path

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -363,8 +363,8 @@ function getFolderContentsById(id, type, isSearchNav) {
 
       mediaFiles.forEach(parseThumbnail);
 
-      mediaFolders.forEach(addFolder);
-      mediaFiles.forEach(addFile);
+      mediaFolders.forEach((folder) => addFolder(folder));
+      mediaFiles.forEach(file =>addFile(file));
 
       renderList();
     }
@@ -1338,9 +1338,9 @@ function renderSearchResult(result, searchType) {
     .map(function(item) {
       item.relativePath = calculatePath(item);
 
-      if (item.parentId) {
+      if (item.parentId || item.mediaFolderId) {
         item.parentItemType = 'folder';
-        item.parentItemId = item.parentId;
+        item.parentItemId = item.parentId || item.mediaFolderId;
       } else if (item.appId) {
         item.parentItemType = 'app';
         item.parentItemId = item.appId;


### PR DESCRIPTION
### What does this PR do?

Fixes detecting parent directory if it has no `parentId` but only `mediaFolderId`. 

Fixes bug occurring on navigating to the parent of search result - functions `addFolder` and `addFile` accept second parameter `isTrash` launching part of logic relying on data available only for deleted files and directories. The functions have been passed directly as forEach function callback, which has a default second argument - `index.` `index` was triggering trashed-items-related logic.

### JIRA ticket

https://weboo.atlassian.net/browse/ID-3973

### Result

https://github.com/Fliplet/fliplet-widget-file-manager/assets/144125903/4e7b3e4f-4d4a-493a-ae1c-3b4e035ef93e


https://github.com/Fliplet/fliplet-widget-file-manager/assets/144125903/22244253-7e90-47e9-a505-12fbd5ed1d64

