### PR TITLE
ID-4064 [fix] navigation to organization search results; app in breadcrumbs and pathways

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -44,8 +44,8 @@
           <div class="spinner-overlay">Loading...</div>
         </div>
         <div class="search-holder">
-          <select class="form-control search-type">
-            <option value="all">This organization</option>
+          <select class="form-control search-type" id="search-type">
+            <option value="organization">This organization</option>
             <option value="this-folder" selected>This folder</option>
           </select>
           <input type="text" class="form-control search-term" placeholder="Search...">
@@ -294,7 +294,7 @@
     -->
     <div class="file-cell search-result-cell file-path-cell">
       <span>
-        <a href="javascript:;" class="path-link" data-folder data-id="\{{parentItemId}}" data-type="\{{parentItemType}}" title="\{{relativePath}}">\{{relativePath}}</a>
+        <a href="javascript:;" class="path-link" data-folder data-id="\{{id}}" data-parent-id="\{{parentItemId}}" data-type="\{{parentItemType}}" title="\{{relativePath}}">\{{relativePath}}</a>
       </span>
     </div>
     <div class="file-cell search-result-cell file-size-cell">
@@ -353,7 +353,7 @@
     -->
     <div class="file-cell search-result-cell file-path-cell">
       <span>
-        <a href="javascript:;" class="path-link" data-folder data-id="\{{parentItemId}}" data-type="\{{parentItemType}}" title="\{{relativePath}}">\{{relativePath}}</a>
+        <a href="javascript:;" class="path-link" data-folder data-id="\{{id}}" data-parent-id="\{{parentItemId}}" data-type="\{{parentItemType}}" title="\{{relativePath}}">\{{relativePath}}</a>
       </span>
     </div>
     <div class="file-cell search-result-cell file-size-cell">

--- a/js/interface.js
+++ b/js/interface.js
@@ -1350,7 +1350,8 @@ function renderSearchResult(result, searchType) {
 
 // Builds a relative path to folder or file
 function calculatePath({ item, showApp }) {
-  const path = [...(showApp  ? [(item.parentFolder || item ).app.name] : [])];
+  const rootApp = showApp && (item.parentFolder || item ).app;
+  const path = [...(rootApp ? [rootApp.name] : [])];
   const separator = '/';
 
   const getNames = function(item) {

--- a/js/interface.js
+++ b/js/interface.js
@@ -28,6 +28,7 @@ var appList;
 // eslint-disable-next-line no-undef
 var appIcons = new Map();
 var currentOrganizationId;
+let currentOrganizationNavItem;
 var currentFolderId;
 var currentAppId;
 var currentFolders;
@@ -747,6 +748,7 @@ function addOrganizations(organizations) {
 
   backItem.type = 'organizationId';
   navStack.push(backItem);
+  currentOrganizationNavItem = backItem;
 
   $('.header-breadcrumbs .current-folder-title').html('<span class="bread-link"><a href="#">' + orgName + '</a></span>');
 
@@ -974,38 +976,20 @@ function updatePaths() {
 }
 
 function resetUpTo(element) {
-  var backItem;
+  const { id, type, appId, orgId } = element[0].dataset;
 
-  navStack = [];
-
-  if (element.attr('data-type') === 'app') {
-    backItem = {
-      id: element.data('app-id'),
-      name: element.find('.list-text-holder span').first().text(),
-      tempElement: element
-    };
-    backItem.type = 'appId';
-  } else if (element.attr('data-type') === 'organization') {
-    backItem = {
-      id: element.data('org-id'),
-      name: element.find('.list-text-holder span').first().text(),
-      tempElement: element
-    };
-    backItem.type = 'organizationId';
-  } else {
-    backItem = {
-      id: element.data('id'),
-      name: element.find('.list-text-holder span').first().text(),
-      tempElement: element
-    };
-    backItem.type = 'folderId';
+  const backItem = {
+    id: type === 'app' && appId || type === 'organization' && orgId || id,
+    name: element.find('.list-text-holder span').first().text(),
+    tempElement: element,
+    type: type === 'app' && 'appId' || type === 'organization' && 'organizationId' || 'folderId',
   }
-
   backItem.back = function() {
     getFolderContents(backItem.tempElement);
   };
 
-  navStack.push(backItem);
+  navStack = [...(type === 'app' ? [currentOrganizationNavItem ]: []), backItem];
+
   updatePaths();
 }
 
@@ -1017,33 +1001,7 @@ function resetToTop() {
 
 function getFoldersData(options, filterFiles, filterFolders) {
   return Fliplet.Media.Folders.get(options).then(function(response) {
-    var navItem = navStack[navStack.length - 1];
 
-    switch (navItem.type) {
-      case 'organizationId':
-        // User is no longer browsing the organization folder
-        if (options.hasOwnProperty('folderId') || !options.hasOwnProperty('organizationId') || parseInt(options.organizationId, 10) !== navItem.id) {
-          return;
-        }
-
-        break;
-      case 'appId':
-        // User is no longer browsing the app folder
-        if (!options.hasOwnProperty('appId') || parseInt(options.appId, 10) !== navItem.id) {
-          return;
-        }
-
-        break;
-      case 'folderId':
-        // User is no longer browsing the folder
-        if (!options.hasOwnProperty('folderId') || parseInt(options.folderId, 10) !== navItem.id) {
-          return;
-        }
-
-        break;
-      default:
-        break;
-    }
 
     if (!$folderContents.is(':empty')) {
       // Content already rendered from a recent request. Do nothing.
@@ -1285,7 +1243,7 @@ function search(type, term) {
     if (currentFolderId) {
       query.folderId = currentFolderId;
     }
-  } else if (type === 'all') {
+  } else if (type !== 'this-folder') {
     if (currentAppId) {
       query.appId = currentAppId;
     } else {
@@ -1319,7 +1277,7 @@ function renderSearchResult(result, searchType) {
     return;
   }
 
-  if (searchType === 'all') {
+  if (searchType !== 'this-folder') {
     resetToTop();
   }
 
@@ -1329,18 +1287,18 @@ function renderSearchResult(result, searchType) {
         return item.deletedAt;
       }
 
-      if (currentAppId || currentFolderId || searchType === 'all') {
+      if (currentAppId || currentFolderId || searchType !== 'this-folder') {
         return !item.deletedAt;
       }
 
       return !item.deletedAt && !item.mediaFolderId && !item.appId;
     })
     .map(function(item) {
-      item.relativePath = calculatePath(item);
+      item.relativePath = calculatePath({ item, showApp: searchType === 'organization'});
 
-      if (item.parentId || item.mediaFolderId) {
+      if (item.parentFolder) {
         item.parentItemType = 'folder';
-        item.parentItemId = item.parentId || item.mediaFolderId;
+        item.parentItemId = item.parentFolder.id;
       } else if (item.appId) {
         item.parentItemType = 'app';
         item.parentItemId = item.appId;
@@ -1391,23 +1349,18 @@ function renderSearchResult(result, searchType) {
 }
 
 // Builds a relative path to folder or file
-function calculatePath(item) {
-  var path = [];
-  var separator = '/';
-  var isLast = false;
+function calculatePath({ item, showApp }) {
+  const path = [...(showApp  ? [(item.parentFolder || item ).app.name] : [])];
+  const separator = '/';
 
-  var getNames = function(item) {
+  const getNames = function(item) {
     if (!item) {
       return;
     }
 
     if (item.parentFolder) {
       getNames(item.parentFolder);
-    } else {
-      isLast = true;
-    }
-
-    if (isLast && item.id === +currentFolderId) {
+    } else if (item.id === +currentFolderId) {
       return;
     }
 
@@ -1450,17 +1403,24 @@ function updateBreadcrumbsBySearchItem(item) {
     return;
   }
 
-  var nav = [];
-  var isLast = false;
+const { app } = item.parentFolder || item;
 
-  var getParents = function(parent) {
+  const nav = [
+   currentOrganizationNavItem,
+    {
+      id: app.id,
+      name: app.name,
+      type: 'appId',
+      back: function() {
+        getFolderContentsById(app.id, 'app');
+      }
+    }
+  ];
+
+  const getParents = function(parent) {
     if (parent.parentFolder) {
       getParents(parent.parentFolder);
-    } else {
-      isLast = true;
-    }
-
-    if (isLast && parent.id === +currentFolderId) {
+    } else if ( parent.id === +currentFolderId) {
       return;
     }
 
@@ -1476,7 +1436,7 @@ function updateBreadcrumbsBySearchItem(item) {
 
   getParents(item);
 
-  navStack = navStack.concat(nav);
+  navStack = nav;
   updatePaths();
 }
 
@@ -1506,13 +1466,27 @@ function removePagination() {
 }
 
 function updateSearchTypeOptions(type) {
-  var optionName = 'This organization';
+  const select = document.getElementById('search-type');
+  const options = [
+    ...(type === "app"
+      ? [
+          {
+            value: "app",
+            label: "This app"
+          }
+        ]
+      : [
+          {
+            value: "organization",
+            label: "This organization"
+          }
+        ]),
+    { value: "this-folder", label: "This folder" }
+  ];
 
-  if (type === 'app') {
-    optionName = 'This app';
-  }
-
-  $searchType.find('option:first').text(optionName);
+  select.innerHTML = options.map(option =>
+      `<option value="${option.value}" ${option.value === 'this-folder' ? 'selected' : ''}>${option.label}</option>`
+    ).join('');
 }
 
 // Shows content of the last folder before run search
@@ -2215,6 +2189,7 @@ $('.file-manager-wrapper')
 
     navStack.splice(position, 9999);
     navStack[index].back();
+    updateSearchTypeOptions(navStack[index].type);
     updatePaths();
   })
   .on('show.bs.collapse', '.panel-collapse', function() {
@@ -2257,19 +2232,16 @@ $('.file-manager-wrapper')
     $searchTermClearBtn.addClass('hide');
   })
   .on('click', '.path-link', function() {
-    var $el = $(this);
-    var type = $el.data('type');
-    var id = $el.data('id');
+    const { id, parentId, type } = this.dataset
 
-    if (type === 'app' || type === 'organization') {
-      resetToTop();
-    } else {
-      var item = _.find(currentSearchResult, ['id', id]);
+    const numId = +id;
+    const item = currentSearchResult.find(item => item.id == numId);
 
-      updateBreadcrumbsBySearchItem(item);
+    if (item) {
+      updateBreadcrumbsBySearchItem(item.parentFolder || item);
     }
 
-    getFolderContentsById(id, type, true);
+    getFolderContentsById(parentId, type, true);
 
     removeSelection();
     hideSideActions();
@@ -2282,7 +2254,7 @@ $('.file-manager-wrapper')
 
     var type = $searchType.val();
 
-    if (type === 'all') {
+    if (type !== 'this-folder') {
       currentFolderId = null;
     }
 

--- a/js/interface.js
+++ b/js/interface.js
@@ -982,13 +982,14 @@ function resetUpTo(element) {
     id: type === 'app' && appId || type === 'organization' && orgId || id,
     name: element.find('.list-text-holder span').first().text(),
     tempElement: element,
-    type: type === 'app' && 'appId' || type === 'organization' && 'organizationId' || 'folderId',
-  }
+    type: type === 'app' && 'appId' || type === 'organization' && 'organizationId' || 'folderId'
+  };
+
   backItem.back = function() {
     getFolderContents(backItem.tempElement);
   };
 
-  navStack = [...(type === 'app' ? [currentOrganizationNavItem ]: []), backItem];
+  navStack = [...(type === 'app' ? [currentOrganizationNavItem ] : []), backItem];
 
   updatePaths();
 }
@@ -1001,8 +1002,6 @@ function resetToTop() {
 
 function getFoldersData(options, filterFiles, filterFolders) {
   return Fliplet.Media.Folders.get(options).then(function(response) {
-
-
     if (!$folderContents.is(':empty')) {
       // Content already rendered from a recent request. Do nothing.
       return;
@@ -1294,7 +1293,7 @@ function renderSearchResult(result, searchType) {
       return !item.deletedAt && !item.mediaFolderId && !item.appId;
     })
     .map(function(item) {
-      item.relativePath = calculatePath({ item, showApp: searchType === 'organization'});
+      item.relativePath = calculatePath({ item, showApp: searchType === 'organization' });
 
       if (item.parentFolder) {
         item.parentItemType = 'folder';
@@ -1350,7 +1349,7 @@ function renderSearchResult(result, searchType) {
 
 // Builds a relative path to folder or file
 function calculatePath({ item, showApp }) {
-  const rootApp = showApp && (item.parentFolder || item ).app;
+  const rootApp = showApp && (item.parentFolder || item).app;
   const path = [...(rootApp ? [rootApp.name] : [])];
   const separator = '/';
 
@@ -1404,10 +1403,10 @@ function updateBreadcrumbsBySearchItem(item) {
     return;
   }
 
-const { app } = item.parentFolder || item;
+  const { app } = item.parentFolder || item;
 
   const nav = [
-   currentOrganizationNavItem,
+    currentOrganizationNavItem,
     {
       id: app.id,
       name: app.name,
@@ -1421,7 +1420,7 @@ const { app } = item.parentFolder || item;
   const getParents = function(parent) {
     if (parent.parentFolder) {
       getParents(parent.parentFolder);
-    } else if ( parent.id === +currentFolderId) {
+    } else if (parent.id === +currentFolderId) {
       return;
     }
 
@@ -1469,25 +1468,25 @@ function removePagination() {
 function updateSearchTypeOptions(type) {
   const select = document.getElementById('search-type');
   const options = [
-    ...(type === "app"
+    ...(type === 'app'
       ? [
-          {
-            value: "app",
-            label: "This app"
-          }
-        ]
+        {
+          value: 'app',
+          label: 'This app'
+        }
+      ]
       : [
-          {
-            value: "organization",
-            label: "This organization"
-          }
-        ]),
-    { value: "this-folder", label: "This folder" }
+        {
+          value: 'organization',
+          label: 'This organization'
+        }
+      ]),
+    { value: 'this-folder', label: 'This folder' }
   ];
 
   select.innerHTML = options.map(option =>
-      `<option value="${option.value}" ${option.value === 'this-folder' ? 'selected' : ''}>${option.label}</option>`
-    ).join('');
+    `<option value="${option.value}" ${option.value === 'this-folder' ? 'selected' : ''}>${option.label}</option>`
+  ).join('');
 }
 
 // Shows content of the last folder before run search
@@ -2233,10 +2232,10 @@ $('.file-manager-wrapper')
     $searchTermClearBtn.addClass('hide');
   })
   .on('click', '.path-link', function() {
-    const { id, parentId, type } = this.dataset
+    const { id, parentId, type } = this.dataset;
 
     const numId = +id;
-    const item = currentSearchResult.find(item => item.id == numId);
+    const item = currentSearchResult.find(item => item.id === numId);
 
     if (item) {
       updateBreadcrumbsBySearchItem(item.parentFolder || item);


### PR DESCRIPTION
Note: follow up to https://github.com/Fliplet/fliplet-widget-file-manager/pull/104

### Product areas affected
File manager

### Description
- fixed resolving paths of search results done within an organization;
- added app name in organization search results path string;
- added app name into breadcrumbs;

### Prerequisites
https://github.com/Fliplet/fliplet-api/pull/6076

## Jira ticket
https://weboo.atlassian.net/browse/ID-4064

## Screenshots
<img width="1431" alt="image" src="https://github.com/Fliplet/fliplet-widget-file-manager/assets/144125903/6042af04-28f3-49f1-beb8-7645bc2fedb1">
<img width="1119" alt="image" src="https://github.com/Fliplet/fliplet-widget-file-manager/assets/144125903/f1e2074c-9a0f-454e-9a66-1ef6a1c3c322">

Latest fix screenshot:
<img width="1371" alt="image" src="https://github.com/Fliplet/fliplet-widget-file-manager/assets/144125903/206ab68a-ccf8-46ca-9cc2-d3c3843af4cb">
