### PR TITLE
ID-4204 [Fix] Ensure file manager loads only current organization

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -75,14 +75,8 @@ function getOrganizationsList() {
 
   showSpinner(true);
 
-  Fliplet.Organizations.get().then(function(organizations) {
-    // Sort alphabetically
-    organizations = _.sortBy(organizations, [function(o) {
-      return o.name;
-    }]);
-    // Add to HTML
-    organizations.forEach(addOrganizations);
-  }).then(function() {
+  Fliplet.Organizations.getCurrentOrganization().then(function(organization) {
+    addOrganizations(organization);
     getAppsList();
     $selectAllCheckbox.addClass('active');
     showSpinner(false);

--- a/widget.json
+++ b/widget.json
@@ -1,7 +1,7 @@
 {
   "name": "File Manager",
   "package": "com.fliplet.file-manager",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "icon": "img/icon.png",
   "tags": ["type:component", "category:general"],
   "provider_only": true,


### PR DESCRIPTION
This PR fixes the bug in [ID-4204](https://weboo.atlassian.net/browse/ID-4204), it is related to [ID-3548](https://weboo.atlassian.net/browse/ID-3548) multi-environment feature.

[ID-4204]: https://weboo.atlassian.net/browse/ID-4204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ID-3548]: https://weboo.atlassian.net/browse/ID-3548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ