### PR TITLE
DEV-1097: fix: use API URLs for files and show DS entry option for folders

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -107,6 +107,27 @@ function parseThumbnail(file) {
   file.thumbnail = Fliplet.Media.authenticate(file.url.replace(Fliplet.Env.get('apiUrl'), Fliplet.Env.get('apiCdnUrl')));
 }
 
+// Builds an authenticated /v1/media/files/:id/contents/:name URL so that
+// mediaAccessControl.enforceFileAccess('read') runs on shared links. When the
+// backend returns an API URL we derive the host from it so the file's own region
+// is preserved (critical for users with orgs across EU/US/CA); otherwise we fall
+// back to the session's apiUrl.
+function buildFileContentUrl(file) {
+  var host = Fliplet.Env.get('apiUrl');
+
+  if (file.url && file.url.indexOf('/v1/media/files/') !== -1) {
+    try {
+      host = new URL(file.url).origin + '/';
+    } catch (err) {
+      // Fall back to session apiUrl
+    }
+  }
+
+  return Fliplet.Media.authenticate(
+    host + 'v1/media/files/' + file.id + '/contents/' + encodeURIComponent(file.name)
+  );
+}
+
 function navigateToRootFolder(options) {
   var $itemFolder = options.appId
     ? $('[data-app-id="' + options.appId + '"][data-browse-folder]')
@@ -840,8 +861,10 @@ function addFolder(folder, isTrash) {
 
 // Adds file item template
 function addFile(file, isTrash) {
-  // Always use the API content endpoint so security rules are enforced when the link is shared
-  file.url = Fliplet.Env.get('apiUrl') + 'v1/media/files/' + file.id + '/contents/' + encodeURIComponent(file.name);
+  // Use the API /contents endpoint so security rules are enforced when the link is
+  // shared. buildFileContentUrl preserves the file's own region, which matters for
+  // users with orgs across EU/US/CA.
+  file.url = buildFileContentUrl(file);
 
   if (isTrash) {
     var fileParent = file.parents[0];

--- a/js/interface.js
+++ b/js/interface.js
@@ -840,6 +840,9 @@ function addFolder(folder, isTrash) {
 
 // Adds file item template
 function addFile(file, isTrash) {
+  // Always use the API content endpoint so security rules are enforced when the link is shared
+  file.url = Fliplet.Env.get('apiUrl') + 'v1/media/files/' + file.id + '/contents/' + encodeURIComponent(file.name);
+
   if (isTrash) {
     var fileParent = file.parents[0];
 
@@ -1147,10 +1150,10 @@ function getFoldersData(options, filterFiles, filterFolders) {
       var mediaFiles = response.files.filter(filterFiles);
       var mediaFolders = response.folders.filter(filterFolders);
 
+      mediaFiles.forEach(parseThumbnail);
+
       Fliplet.Utils.forEach(mediaFolders, function(item) { addFolder(item, false); });
       Fliplet.Utils.forEach(mediaFiles, function(item) { addFile(item, false); });
-
-      mediaFiles.forEach(parseThumbnail);
 
       $('.file-date-cell').show();
       $('.file-deleted-cell').hide();
@@ -1185,10 +1188,10 @@ function getTrashFilesData(filterFiles, filterFolders) {
       var mediaFiles = result.files.filter(filterFiles);
       var mediaFolders = result.folders.filter(filterFolders);
 
+      mediaFiles.forEach(parseThumbnail);
+
       Fliplet.Utils.forEach(mediaFolders, function(item) { addFolder(item, true); });
       Fliplet.Utils.forEach(mediaFiles, function(item) { addFile(item, true); });
-
-      mediaFiles.forEach(parseThumbnail);
 
       $('.file-deleted-cell').removeClass('hidden');
       $('.file-date-cell').hide();

--- a/js/security-rules.js
+++ b/js/security-rules.js
@@ -1333,15 +1333,6 @@
       $createCheckbox.hide().find('input').prop('checked', false).prop('disabled', true);
     }
 
-    // Data source entry rules are file-only (API rejects them on folders)
-    const $dsButton = $editor.find('[data-allow-type="dataSource"]');
-
-    if (isFolder) {
-      $dsButton.hide();
-    } else {
-      $dsButton.show();
-    }
-
     // "Applies to" (app scope) — hide for org rules since org files have no app
     const isOrganization = currentSecurityTarget && currentSecurityTarget.type === 'organization';
     const $appScopeSection = $editor.find('.rule-app-scope-section');

--- a/widget.json
+++ b/widget.json
@@ -1,6 +1,6 @@
 {
   "name": "File Manager",
-  "package": "com.fliplet.file-manager",
+  "package": "com.fliplet.file-manager-eu",
   "version": "1.0.0",
   "icon": "img/icon.png",
   "tags": ["type:component", "category:general"],

--- a/widget.json
+++ b/widget.json
@@ -1,6 +1,6 @@
 {
   "name": "File Manager",
-  "package": "com.fliplet.file-manager-eu",
+  "package": "com.fliplet.file-manager",
   "version": "1.0.0",
   "icon": "img/icon.png",
   "tags": ["type:component", "category:general"],


### PR DESCRIPTION
## Summary
- **API URLs for files**: File open/share links now use the API content endpoint (`/v1/media/files/{id}/contents/{name}`) instead of direct CDN/S3 URLs, so `mediaAccessControl.enforceFileAccess('read')` middleware enforces security rules when links are shared externally.
- **Data Source Entries for folders**: The "Data Source Entries" access rule option is now available for folders, not just files.
- Reordered `parseThumbnail` to run before `addFile` in all code paths so thumbnails are generated from the original URL before the API URL rewrite.

## Test plan
- [ ] Open the file manager, double-click a file — verify it opens via API URL (check the URL bar)
- [ ] Right-click and copy the file link — verify it's an API URL, not a CDN/S3 URL
- [ ] Share the copied link in an incognito window — verify access rules are enforced
- [ ] Open access rules on a folder — verify the "Data Source Entries" button is visible
- [ ] Open access rules on a file — verify the "Data Source Entries" button is still visible
- [ ] Verify file thumbnails still display correctly in all views (folder browse, trash, search)

🤖 Generated with [Claude Code](https://claude.com/claude-code)