### PR TITLE
feat: rename apps → projects (v3 user-visible wording)

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -23,7 +23,7 @@
         </h4>
       </div>
       <div class="storage-holder hidden">
-        <p><strong>Storage for <span>app name</span></strong></p>
+        <p><strong>Storage for <span>project name</span></strong></p>
         <div class="storage-progress-holder">
           <div class="progress">
             <div class="progress-bar" role="progressbar" aria-valuemin="0" aria-valuenow="0" aria-valuemax="500" style="width: 0%;"></div>
@@ -173,7 +173,7 @@
               <!-- Populated by security-rules.js -->
             </div>
             <div class="folder-no-rules-callout callout callout-warning" style="display: none;">
-              <p>No access rules. Contents of this folder won't be accessible to app users unless they have their own rules.</p>
+              <p>No access rules. Contents of this folder won't be accessible to project users unless they have their own rules.</p>
             </div>
             <div class="folder-security-open-action">
               <button class="btn btn-default btn-sm btn-open-folder-rules">Access rules</button>
@@ -184,7 +184,7 @@
           <div class="help-tips hidden">
             <h2>Did you know?</h2>
             <p>All users from an organization can access <strong>Organization</strong> folders and edit its content.</p>
-            <p>You can make files only accessible to specific apps. Use the menu on the left to browse app specific files.</p>
+            <p>You can make files only accessible to specific projects. Use the menu on the left to browse project specific files.</p>
           </div>
 
           <!-- Side actions (shown when items are selected) -->
@@ -202,7 +202,7 @@
             <!-- No access rules alert (shown between file info and Action button) -->
             <div class="selected-no-rules-section" style="display: none;">
               <div class="callout callout-warning">
-                <p>No access rules. This item won't be accessible to app users.</p>
+                <p>No access rules. This item won't be accessible to project users.</p>
               </div>
             </div>
 
@@ -647,12 +647,12 @@
           <div class="row rule-app-scope-section">
             <div class="col-md-4">
               <h5>Applies to</h5>
-              <p>Select apps affected by this rule.</p>
+              <p>Select projects affected by this rule.</p>
             </div>
             <div class="col-md-8 side vertical">
               <div>
-                <button data-app-scope="all" type="button" class="btn btn-default selected">All apps</button>
-                <button data-app-scope="filter" type="button" class="btn btn-default"><i class="fa fa-filter fa-fw"></i> Specific apps</button>
+                <button data-app-scope="all" type="button" class="btn btn-default selected">All projects</button>
+                <button data-app-scope="filter" type="button" class="btn btn-default"><i class="fa fa-filter fa-fw"></i> Specific projects</button>
               </div>
               <div class="apps-list apps-list-wrapper hidden">
                 <!-- Populated by JS -->

--- a/js/interface.js
+++ b/js/interface.js
@@ -702,7 +702,7 @@ function getFolderContents(el, isRootFolder) {
   if (el.attr('data-type') === 'app') {
     options.appId = el.attr('data-app-id');
     currentAppId = el.attr('data-app-id');
-    currentAppName = el.find('.list-text-holder span').text() || 'App Files';
+    currentAppName = el.find('.list-text-holder span').text() || 'Project Files';
     currentFolderId = null;
 
     // Update security rules role for this app context
@@ -1129,7 +1129,7 @@ function resetUpTo(element) {
   // Set app context before updatePaths so breadcrumb dropdown includes access rules
   if (type === 'app') {
     currentAppId = appId;
-    currentAppName = element.find('.list-text-holder span').first().text() || 'App Files';
+    currentAppName = element.find('.list-text-holder span').first().text() || 'Project Files';
   } else if (type === 'organization') {
     currentAppId = null;
     currentAppName = null;
@@ -1161,7 +1161,7 @@ function getFoldersData(options, filterFiles, filterFolders) {
 
       // Update folder security card even for empty folders
       if (window.FileSecurityRules) {
-        var folderName = navStack.length > 0 ? navStack[navStack.length - 1].name : (currentAppName || 'App Files');
+        var folderName = navStack.length > 0 ? navStack[navStack.length - 1].name : (currentAppName || 'Project Files');
         var folderId = currentFolderId || 'root';
 
         window.FileSecurityRules.updateFolderSecurityCard(folderId, folderName);
@@ -1345,7 +1345,7 @@ function renderList() {
 
   // Update folder security card with current folder context
   if (window.FileSecurityRules) {
-    var folderName = navStack.length > 0 ? navStack[navStack.length - 1].name : (currentAppName || 'App Files');
+    var folderName = navStack.length > 0 ? navStack[navStack.length - 1].name : (currentAppName || 'Project Files');
     var folderId = currentFolderId || 'root';
 
     window.FileSecurityRules.updateFolderSecurityCard(folderId, folderName);
@@ -1646,7 +1646,7 @@ function updateSearchTypeOptions(type) {
       ? [
         {
           value: 'app',
-          label: 'This app'
+          label: 'This project'
         }
       ]
       : [
@@ -2121,7 +2121,7 @@ $('.file-manager-wrapper')
 
     if (window.FileSecurityRules) {
       var folderId = currentFolderId || 'root';
-      var folderName = navStack.length > 0 ? navStack[navStack.length - 1].name : (currentAppName || 'App Files');
+      var folderName = navStack.length > 0 ? navStack[navStack.length - 1].name : (currentAppName || 'Project Files');
 
       window.FileSecurityRules.openSecurityPanel('folder', folderId, folderName);
     }
@@ -2595,7 +2595,7 @@ $('.file-manager-wrapper')
       name: 'app-settings',
       options: {
         size: 'large',
-        title: 'App Settings',
+        title: 'Project Settings',
         appId: selectedAppId,
         section: 'appBilling',
         helpLink: 'https://help.fliplet.com/app-settings/'

--- a/js/security-rules.js
+++ b/js/security-rules.js
@@ -333,7 +333,7 @@
     if (isOrg) {
       displayName = folderName || 'Organization Files';
     } else {
-      displayName = folderName || (typeof currentAppName !== 'undefined' && currentAppName) || 'App Files';
+      displayName = folderName || (typeof currentAppName !== 'undefined' && currentAppName) || 'Project Files';
     }
 
     $card.find('.folder-access-name').text(displayName);
@@ -470,17 +470,17 @@
 
   function describeApps(rule) {
     if (!rule.appId || (Array.isArray(rule.appId) && rule.appId.length === 0)) {
-      return 'All apps';
+      return 'All projects';
     }
 
-    if (rule.appId === null) return 'All apps';
+    if (rule.appId === null) return 'All projects';
 
     const ids = Array.isArray(rule.appId) ? rule.appId : [rule.appId];
 
     const names = ids.map(function(id) {
       const app = appsList.find(function(a) { return a.id === id; });
 
-      return app ? escapeHtml(app.name) : 'App ' + id;
+      return app ? escapeHtml(app.name) : 'Project ' + id;
     });
 
     return names.join(', ');
@@ -773,7 +773,7 @@
       } else {
         updateFolderSecurityCard(
           $card.data('folder-id') || 'root',
-          $card.data('folder-name') || 'App Files'
+          $card.data('folder-name') || 'Project Files'
         );
       }
     }
@@ -836,11 +836,11 @@
 
     if (own.length > 0 && isOrg) {
       html = '<div class="callout callout-primary">' +
-        '<p>Organization-level access rules. Apps and files without their own rules will inherit these.</p>' +
+        '<p>Organization-level access rules. Projects and files without their own rules will inherit these.</p>' +
         '</div>';
     } else if (own.length === 0 && isOrg) {
       html = '<div class="callout callout-warning">' +
-        '<p>No organization-level access rules. Files without app or folder rules will be denied.</p>' +
+        '<p>No organization-level access rules. Files without project or folder rules will be denied.</p>' +
         '</div>';
     } else if (own.length > 0 && !isRoot && !isFile) {
       html = '<div class="callout callout-primary">' +
@@ -861,7 +861,7 @@
       if (effective.inheritedFrom.type === 'organization') {
         inheritSource = 'organization';
       } else if (effective.inheritedFrom.type === 'app') {
-        inheritSource = 'app';
+        inheritSource = 'project';
       }
 
       html = '<div class="callout callout-primary">' +
@@ -871,7 +871,7 @@
     } else if (effective.rules.length === 0) {
       html = '<div class="callout callout-warning">' +
         '<p>No access rules. This ' + currentSecurityTarget.type +
-          ' is not accessible to app users. Add rules below.</p>' +
+          ' is not accessible to project users. Add rules below.</p>' +
         '</div>';
     }
 
@@ -1056,10 +1056,10 @@
           .data('folder-name', inheritedName)
           .data('inherited-type', 'organization');
       } else if (effective.inheritedFrom.type === 'app') {
-        inheritedName = effective.inheritedFrom.appName || (typeof currentAppName !== 'undefined' ? currentAppName : 'App Files');
+        inheritedName = effective.inheritedFrom.appName || (typeof currentAppName !== 'undefined' ? currentAppName : 'Project Files');
         inheritedId = 'root';
 
-        $section.find('.inherited-from-path').text('Inherited from app: ' + inheritedName);
+        $section.find('.inherited-from-path').text('Inherited from project: ' + inheritedName);
         $section.find('[data-edit-inherited-rules]')
           .show()
           .data('folder-id', inheritedId)
@@ -1102,7 +1102,7 @@
 
   let editingRuleIndex = null; // null = adding new, number = editing existing
   let dataSourcesList = [];    // Cached data sources for the select dropdown
-  let appsList = [];           // Cached apps for the "Specific apps" checkboxes
+  let appsList = [];           // Cached projects for the "Specific projects" checkboxes
   let tokensList = [];         // Cached tokens for the "Specific token" select
   let panelContextStack = [];  // Stack for navigating between inherited folder contexts
   let customRuleEditor = null; // CodeMirror instance for custom JS rules
@@ -1771,7 +1771,7 @@
           } else {
             updateFolderSecurityCard(
               $card.data('folder-id') || 'root',
-              $card.data('folder-name') || 'App Files'
+              $card.data('folder-name') || 'Project Files'
             );
           }
         }
@@ -1812,7 +1812,7 @@
       const $card = $('.folder-security-card');
       const cardType = $card.data('folder-type');
       const folderId = $card.data('folder-id') || 'root';
-      const folderName = $card.data('folder-name') || 'App Files';
+      const folderName = $card.data('folder-name') || 'Project Files';
 
       if (cardType === 'organization') {
         openSecurityPanel('organization', folderId, folderName);
@@ -2132,7 +2132,7 @@
       if (hadRules && hasNoRules) {
         Fliplet.Modal.confirm({
           title: 'Remove all access rules?',
-          message: 'This ' + currentSecurityTarget.type + ' will no longer be accessible to app users.',
+          message: 'This ' + currentSecurityTarget.type + ' will no longer be accessible to project users.',
           buttons: {
             cancel: {
               label: 'Cancel',
@@ -2247,7 +2247,7 @@
     // Initial badge update — only when app context exists
     if (getAppId()) {
       setTimeout(updateSecurityBadges, 500);
-      updateFolderSecurityCard('root', 'App Files');
+      updateFolderSecurityCard('root', 'Project Files');
       $('.help-tips').addClass('hidden');
     }
   }


### PR DESCRIPTION
## Summary

User-visible "Apps → Projects" rename to align with the v3 Studio rename shipped in Fliplet/fliplet-studio#8518.

## Scope (27 strings across 3 files)

- `interface.html`: "Storage for app name" → "project name", "All apps" / "Specific apps" rule scope buttons, "Select apps affected" → "projects"
- `js/security-rules.js`: "All apps" describer, "App Files" fallback (multiple), "Inherited from app" → "project", "Files without app or folder rules" → "project", inheritedType `'app'` string-value where rendered
- `js/interface.js`: "App Files" fallback (5 occurrences), "This app" search filter, **"App Settings" overlay title → "Project Settings"**

## What was kept

- All CSS class names (`.app-holder`, `.app-overlay`, `.apps-list`)
- DOM ids, data attributes (`data-app-id`, `data-app-scope`)
- API paths (`v1/media/apps/`, `v1/apps/`)
- Internal type-string values
- Overlay route name `app-settings` and section id `appBilling`
- `Fliplet.Apps.get` public API

🤖 Generated with [Claude Code](https://claude.com/claude-code)