### PR TITLE
DEV-1342: fix: rebuild served /contents URL on rename

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -2396,14 +2396,32 @@ $('.file-manager-wrapper')
 
       await updatePromise;
 
-      $('.file-row[data-id="' + itemID + '"]').find('.file-name span').html(changedName);
+      const $renamedRow = $('.file-row[data-id="' + itemID + '"]');
+
+      $renamedRow.find('.file-name span').html(changedName);
+      $renamedRow.attr('data-name', changedName);
 
       if (itemType === 'folder') {
         const folder = currentFolders.find(folder => folder.id === itemID);
         if (folder) folder.name = changedName;
       } else {
         const file = currentFiles.find(file => file.id === itemID);
-        if (file) file.name = changedName;
+
+        if (file) {
+          file.name = changedName;
+
+          // Rebuild the authenticated /contents/<name> URL so the served URL,
+          // Open action and any shared/copied link reflect the new name.
+          // buildFileContentUrl embeds file.name, but file.url and the row's
+          // data-file-url are frozen at render time (see addFile), so without
+          // this they keep pointing at the old upload name.
+          file.url = buildFileContentUrl(file);
+
+          // Update the attribute AND jQuery's cached .data() value — the Open
+          // and preview handlers read .data('file-url'), which is cached from
+          // the attribute on first access and is not refreshed by .attr() alone.
+          $renamedRow.attr('data-file-url', file.url).data('file-url', file.url);
+        }
       }
     } catch (err) {
       Fliplet.Modal.alert({


### PR DESCRIPTION
## Problem
When a file is renamed in the File Manager, the served content URL kept the **original** name. The File Manager builds the `/contents/<name>` URL from `file.name` at render time (`addFile` → `buildFileContentUrl`) and the rename handler never rebuilt it, so the served URL, the **Open** action and any shared/copied link kept pointing at the old upload name (e.g. `…/contents/2.png` after renaming to `pic.png`).

## Fix
In the rename handler (`js/interface.js`), after the name is updated:
- rebuild `file.url` via `buildFileContentUrl(file)` (it embeds the current `file.name`),
- update the row's `data-file-url` (both the attribute **and** jQuery's cached `.data()` value — the Open/preview handlers read `.data('file-url')`),
- update `data-name`.

So after a rename the served URL reflects the new name immediately, e.g. `…/v1/media/files/<id>/contents/pic.png`.

## Scope / notes
- The `/contents/:fileName` route serves by **file id** and ignores the name segment, so this is a safe, cosmetic URL change — no server change required.
- Existing files already show the correct name on a fresh File Manager load (the URL is built from the current name on render); this fixes the in-session rename case.
- **Out of scope (intentionally):** the underlying S3 object key is not re-keyed (that would break already-shared links). Server-side-encrypted files (e.g. videos) still redirect to the raw S3 object on open, so their S3 URL shows the original key — covered separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)